### PR TITLE
macOS check.py

### DIFF
--- a/server_check/check.py
+++ b/server_check/check.py
@@ -317,7 +317,7 @@ def send_message_before_login():
     message = generate_message()
     
     expected_output = "BAD-RQST-HDR"
-    _, output = execute_and_wait(f'echo "SEND {client_name_1} {message}" | nc 127.0.0.1 5378 -W 1')
+    _, output = execute_and_wait(f'echo "SEND {client_name_1} {message}" | nc 127.0.0.1 5378 -w 1')
     
     if not expected_output in output:
         raise TestException(f"your sever did not return BAD-RQST-HDR when trying to send messages before logging in. Answer was '{output}'")


### PR DESCRIPTION
on Mac there is no -W flag so the test was faulty, fortunately there is a -w flag which fixes the problem